### PR TITLE
Improve local mods & assets path

### DIFF
--- a/noworkshop/index.html
+++ b/noworkshop/index.html
@@ -47,7 +47,7 @@ It's possible to run no workshop mode by using a steam parameter, but adding or 
 <p>and the folder name matches the id seen in the workshop item URL.</p>
 
 <p>You can copy mod and asset folders to the corresponding local folders located here:</p>
-<p><span class="path">C:\Users\USERNAME\AppData\Local\Colossal Order\Cities_Skylines\Addons</span></p>
+<p><span class="path">%LocalAppData%\Colossal Order\Cities_Skylines\Addons</span></p>
 
 <p>The AppData folder is hidden by default, you can access it by pressing <span class="key">Windows + R</span> and typing in appdata.</p>
 


### PR DESCRIPTION
Change the path in the No Workshop article from `C:\Users\USERNAME\AppData\Local\Colossal Order\Cities_Skylines\Addons` to `%LocalAppData%\Colossal Order\Cities_Skylines\Addons`.
